### PR TITLE
Add Event GuideLines from Event playbook

### DIFF
--- a/event_guidelines.md
+++ b/event_guidelines.md
@@ -1,1 +1,125 @@
-# TBA
+# Gevent GuideLines
+
+## TABLE OF CONTENTS
+* [PEP-TALK](##PEP-TALK)
+* [BUILD TEAM INCREDIBLE](##BUILD-TEAM-INCREDIBL)
+* [PLAN YOUR EVENT](##PLAN-YOUR-EVENT)
+* [HASHTAG #APPLAUDHER](##HASHTAG-#APPLAUDHER)
+* [CORE PROGRAM FORMATS](##CORE-PROGRAM-FORMATS)
+* [EVENT CHECKLIST](##EVENT-CHECKLIST)
+
+## PEP-TALK
+Dear awesome WWCode Leader, 
+Congratulations! You’ve stepped into leadership with Women Who Code. Now what? 
+In-person events are one of WWCode’s main program avenues. They inspire the community and build the network. Most importantly, they inspire members with the skills and confidence needed to advance their technical careers.  
+We know that you’ve got this. You are passionate about inspiring other women in tech, have experience in the industry, and are ready to share your skills and knowledge.  
+Use this document to better understand the flow of an in-person event and start to make your plans. Don’t forget to engage your network leadership team. They will have lots of ideas and will be ready to help. 
+Be sure to promote your event well in advance and remind your network as the date approaches to make sure that as many people as possible have the chance to participate. 
+Finally, share your progress and any questions with the Global Leadership team (global@womenwhocode.com), and be sure to tweet and share photos and success stories about the event. As you engage in leadership and see your own skills evolve, take note of your thoughts, learnings, how you overcome challenges, how people respond to the movement, etc. 
+If you feel inspired, feel free to write a blog about your own experience. Your story will motivate others and we can post it to your network page on womenwhocode.com:)    
+Good luck with your next event! 
+Best,
+Joey, Jodi, +the Global Team
+
+
+## BUILD TEAM INCREDIBLE
+
+Each event will require a solid leadership team. It’s easier and more fun with a friend! We recommend that at least 2 leaders are involved in the planning team for each event. Here are some roles that might engage. Directors or other leaders may step in, especially in the beginning or if these roles are not filled.  
+
+**Evangelists might:**
+
+* Create content to describe the event. 
+Promote the event on social media.
+* Take photos and share tweets / facebook posts during the event. 
+
+** For Technical Study Groups, Leads might:** 
+* Design technical program. This might include: 
+* Selecting a tutorial from the WWCode Github repository to be used for a study group.
+* Inviting engineers or guests to give product demos or technical talks.
+* Prep any event materials or slideshows.
+* Lead the event program.   
+* Serve as a mentor during the event to motivate people and keep them going. 
+
+** For monthly and special events, Directors or other network leadership team members might: ** 
+* Design the program.
+* Invite speakers and guests to participate. 
+* Prep any event materials or slideshows.
+* Lead the event program.  
+* Welcome guests and participants.
+* Thank the event host. 
+* Moderate panels.
+* Introduce speakers.
+* Give a WWCode update. 
+
+
+## PLAN YOUR EVENT
+A WWCode Hack Night is a great first event, especially when combined with a panel or a few lightning talks.  A hack night is more social than technical, and has a fluid, open program. 
+Events often happen in the evening, after work. They could also happen during the day, if it fits better with the tech culture in your city. Popular event times are: 6.30p - 8.30p and 7p - 9p. 
+
+**Sample 2 hour event outline:**
+* **:30 - Event Check-in, eating, networking** Pro Tip: this 30 minutes will allow for a bit of a buffer in case people run late or need to check in with building security.
+* **:05 - Recognize host + given them up to 5 min to address the community** Pro Tip: Display their logo on a slide. Suggest that the company use this time to have an engineer share how awesome it is to work for their company and offer tips on how to apply OR give a short product demo. 
+* **:05 - Introductions Pro Tip:** For a small group, use WWCode style intros by asking everyone to answer a fun question. For large groups, ask people to introduce themselves to 2 people near them - they can still answer the fun question OR hold a raffle and invite 5 people to introduce themselves to the audience.
+* **:05 - WWCode overview or update Pro Tip:** Use the director starter talk deck as a reference. Share updates about your network or the organization, highlight key successes, call out upcoming events, remind members about the Code of Conduct, and celebrate #ApplaudHers.
+* **:60 - Core program ProTip:** For a Hack Night, each member has the opportunity to make an announcement - it could be what they are currently doing or something that they hope to see in their community to propel women in tech. Yours should be that you would like to meet with anyone who has ideas about how to make WWCode in your city awesome. After the announcements, people can connect to exchange ideas and talk more about what they heard. A hack night can be even more successful if it opens with a short panel or a few lightning talks to get things started.  
+* **:15 - Final questions / networking / coding / clean up** Pro Tip: End on time. Clean up. Leave the room better than you found it. We want to make sure that the host wants to have us back:)  
+
+## HASHTAG #APPLAUDHER
+
+*#ApplaudHer* is a great add on to any event. Some ways to incorporate #ApplaudHer into your next event: 
+Create an #ApplaudHer wall where members can post successes of theirs or others as they are networking. Members could write on post it notes and stick them, you could post flip charts, or use a dry erase board. 
+Ask your audience to raise their hand if they’ve experienced a career success in the last 6 months. Next, call on members to stand and share their story in 60 seconds or less. This showcases your members while adding lightning talks to your program:) 
+
+## CORE PROGRAM FORMATS
+
+Most events follow a similar outline. The core program is what makes the event unique. Here are some common formats: 
+
+### Technical Study Groups 
+Technical study groups are the most common event type. A lead will choose a tutorial from the WWCode Github repository or other technical project. Participants can either choose to work through the tutorial at their own pace or work on their own project. This means that people of all levels can participate at the same time. Leads serve as mentors to help when people find themselves blocked or needing help. 
+
+### Panel Event 
+Panel events are a great way to invite multiple voices to discuss key topics. You might have 4 - 5 panel members + a moderator for a one hour core program. Pro Tip: the moderator should have a call to prep panelists in advance to get to know a little about them and prep them for the discussion. Ask panelists to share with the moderator any key questions that they’d like to answer or topics that they’d like to discuss. Encourage panelists to have dialogue on stage about each question, if they have something to add. Be sure to allow time for audience questions (and maybe ask a few specific people to prepare questions to get things going). Finally, go out with a bang! Consider a final question to wrap up the event. You might want to share this with panelists in advance so that they can prepare. For example: in 10 words or less, what advice would you offer someone who is interested in a career in tech. 
+
+### Fireside Chat
+Fireside chats are a chance to have an intimate conversation with a top tech leader in front of an audience. There is an interviewer who asks the executive questions, about their career, company, or expertise. Pro Tip: the interviewer should connect with the executive in advance to discuss what questions will be asked and any key topics that they would like to discuss or avoid. Members can submit questions in advance that the interviewer can use. Often, executives may opt not to take audience questions during the event to avoid surprises. Determine this in advance so everyone will be comfortable. 
+
+### Keynote Speakers 
+Keynotes are a chance for engineers and tech leaders to share their knowledge. Keynotes can range from 15 minutes to one hour. Often, speakers will take audience questions as part of their keynote. Pro Tip: connect in advance with speakers to determine what audio-visual support they will need. For example, they might require a projector, remote clicker, want to play a video, bring their own laptop, or share slides in advance. 
+
+### Lightning Talks
+Lightning talks are a series of shorter key notes. They range from 60 seconds to 15 minutes. This is a great first speaking experience for engineers who have knowledge to share, but might be a bit nervous about giving a longer talk. It’s also a great way to fill your event with dynamic content and diverse voices from within WWCode’s membership. At the end of the event, you might want to call all speakers to the front to take audience questions together. You can also do a ‘last call’ for impromptu lighting talks that might have been inspired throughout the evening. Pro Tip: Be sure to connect with speakers in advance to determine what audio-visual support they will need. For example, they might require a projector, remote clicker, want to play a video, bring their own laptop, or share slides in advance.  
+
+### Product Demos 
+Product demos are an opportunity for companies to showcase their products and for our members to build their tech skills. Examples include: product APIs and best practices for using the platform or product. Pro Tip: encourage the company to donate access to the product for each member. Consider having members use the product in a project so that they can gain hands on experience. 
+
+## EVENT CHECKLIST
+
+To help you plan, here’s a checklist that can be used for each event: 
+
+- [ ] Identify the event planning team; example:
+  - [ ] 1 - 2 Directors
+  - [ ] 1 - 2 Leads
+  - [ ] 1 Evangelist
+  - [ ] Other event volunteers, as needed	
+- [ ] Choose topic / event style
+    - [ ] Program focus: technical skills, leadership, writing, speaking, career 
+    - [ ] Style: hack night, study group, panel, lightning talks, product demo, etc.
+- [ ] Plan an agenda
+- [ ] Confirm Host and what the facility offers:
+    - [ ] Food & drinks
+    - [ ] Internet
+    - [ ] Size / breakout rooms, if needed
+    - [ ] Wifi
+    - [ ] AV, projectors, etc.
+- [ ] Confirm speakers and external guests 
+- [ ] Post event on Meetup
+- [ ] Promote and marketing the event through social media
+- [ ] Conduct an awesome event; you might need: 
+    - [ ] Presentation / materials
+    - [ ] WWCode Stickers
+    - [ ] Name tags
+- [ ] Complete your post event wrap
+    - [ ] Email / tweet thanks to speakers, host, and volunteers
+    - [ ] Planning team retro to review what went well and any improvements
+    - [ ] Share best practices / key learnings with other leaders
+- [ ] Repeat!:)

--- a/event_guidelines.md
+++ b/event_guidelines.md
@@ -1,4 +1,4 @@
-# Gevent GuideLines
+# Event GuideLines
 
 ## TABLE OF CONTENTS
 * [PEP-TALK](##PEP-TALK)


### PR DESCRIPTION
이벤트 플레이북의 가이드 내용을 추가합니다. 
/ko(번역본), /en(원본) 으로 폴더를 나누면 어떨까 싶어요. 